### PR TITLE
fix src MAC address error when using option -s 2.

### DIFF
--- a/udp.c
+++ b/udp.c
@@ -348,8 +348,6 @@ void udp_genpackets(unsigned char* mem) {
 			} else
 				bcopy(srcd,&src,  6);
 
-			bcopy(srcd,&src,  6);
-
 			if (!dsts) {
 				u_int8_t dstd[6] = {0xff,0xff,0xff,0xff,0xff,0xff}; //Dst mac
 				bcopy(dstd, &dst,  6);


### PR DESCRIPTION
Fix issue: when using option `-s 2`, source MAC address is not random.
